### PR TITLE
enhance layout for ultra-wide displays

### DIFF
--- a/src/app/components/Carousel.jsx
+++ b/src/app/components/Carousel.jsx
@@ -280,7 +280,7 @@ export default function Carousel() {
                 </div>
 
                 <div className="pb-4">
-                    <div className="w-[340px] lg:w-[340px] h-1 bg-white dark:bg-blue-dark mb-2">
+                    <div className="progress-bar-container h-1 bg-white dark:bg-blue-dark mb-2">
                         <div
                             className="h-full bg-blue-dark dark:bg-white"
                             style={{ width: `${progress}%` }}
@@ -325,7 +325,7 @@ export default function Carousel() {
                         </button>
                     </div>
 
-                    <footer className="flex flex-col sm:flex-row gap-2 sm:gap-x-2 mt-4 mb-8 text-base w-[340px] lg:w-[340px]">
+                    <footer className="footer-container flex flex-col sm:flex-row gap-2 sm:gap-x-2 mt-4 mb-8 text-base">
                         <a href="https://t.me/BitPolitoForum" target="_blank" rel="noopener noreferrer" className={"btn-w gap-3 flex-1 min-h-[44px] order-2 sm:order-1"}>
                             <img src={"icons/bitpolito-icon-social-telegram.svg"} className="w-6 h-6 flex-shrink-0 dark:invert dark:brightness-0 dark:filter-white"></img>
                             <span className="button-font">{t("telegram")}</span>

--- a/src/app/components/Chessboard.jsx
+++ b/src/app/components/Chessboard.jsx
@@ -275,7 +275,7 @@ export default function Chessboard() {
             .filter(row => row.length > 0);
 
     return (
-        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="chessboard-container w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             {/* Loading indicator */}
             {isLoading && (
                 <div className="flex justify-center items-center py-12">
@@ -313,7 +313,7 @@ export default function Chessboard() {
 
             {/* Chessboard grid */}
             {!isLoading && (
-                <div className="grid grid-cols-1 chessboard-responsive gap-3 sm:gap-4 lg:gap-5 p-2 sm:p-4 lg:p-5">
+                <div className="chessboard-grid-container grid grid-cols-1 chessboard-responsive gap-3 sm:gap-4 lg:gap-5 p-2 sm:p-4 lg:p-5">
                     {filteredLayout.slice(0, visibleRows).flatMap((row, rowIndex) =>
                         row.map((item, colIndex) => (
                             <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,6 +101,54 @@ h6 {
   }
 }
 
+@media (min-width: 2026px) {
+  .img-carousel {
+    width: 540px;
+  }
+}
+
+.progress-bar-container {
+  width: 340px;
+}
+
+@media (min-width: 2026px) {
+  .progress-bar-container {
+    width: 540px;
+  }
+}
+
+.footer-container {
+  width: 340px;
+}
+
+@media (min-width: 2026px) {
+  .footer-container {
+    width: 540px;
+  }
+}
+
+.carousel-desktop-container {
+  width: 460px;
+}
+
+@media (min-width: 2026px) {
+  .carousel-desktop-container {
+    width: 690px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .main-content-wrapper {
+    margin-right: 460px;
+  }
+}
+
+@media (min-width: 2026px) {
+  .main-content-wrapper {
+    margin-right: 690px;
+  }
+}
+
 .carousel-mobile {
   @apply block;
 }
@@ -140,6 +188,42 @@ h6 {
 
   .chessboard-span-2 {
     @apply col-span-2;
+  }
+}
+
+.chessboard-grid-container {
+  gap: 0.75rem;
+  padding: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .chessboard-grid-container {
+    gap: 1rem;
+    padding: 1rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .chessboard-grid-container {
+    gap: 1.25rem;
+    padding: 1.25rem;
+  }
+}
+
+@media (min-width: 2026px) {
+  .chessboard-grid-container {
+    gap: 2rem;
+    padding: 2rem;
+  }
+}
+
+.chessboard-container {
+  max-width: 80rem;
+}
+
+@media (min-width: 2026px) {
+  .chessboard-container {
+    max-width: 100rem;
   }
 }
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -36,6 +36,7 @@ export default function HomePage() {
         sm:mr-0 sm:ml-0 sm:break-words
         lg:flex-1 lg:overflow-y-auto lg:min-h-screen
         lg:pr-20 lg:pl-2 lg:break-words lg:mr-[460px]
+        main-content-wrapper
         text-sm sm:text-base
         overflow-x-hidden
       ">
@@ -80,7 +81,7 @@ export default function HomePage() {
             <Chessboard />
           </div>
 
-          <div className={`bg-white dark:bg-blue-dark carousel-desktop w-[460px] h-screen p-2 ml-auto transition-all duration-300 top-0 right-0 ${isCarouselFixed ? "fixed" : "absolute"}`}>
+          <div className={`bg-white dark:bg-blue-dark carousel-desktop carousel-desktop-container w-[460px] h-screen p-2 ml-auto transition-all duration-300 top-0 right-0 ${isCarouselFixed ? "fixed" : "absolute"}`}>
             <Carousel />
           </div>
         </div>


### PR DESCRIPTION
- Increase carousel image width from 340px to 420px
- Expand carousel container from 460px to 540px
- Enlarge chessboard max-width to 1600px with bigger gaps
- Adjust main content margins for wider carousel
- Use pure CSS media queries instead of Tailwind classes